### PR TITLE
[FE] 이슈 리스트 컴포넌트 설계

### DIFF
--- a/FE/src/components/Issues/IssueTable/IssueList/AvatarStack/Avatar.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/AvatarStack/Avatar.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Avatar = () => {
+  return <div />;
+};
+
+export default Avatar;

--- a/FE/src/components/Issues/IssueTable/IssueList/AvatarStack/AvatarStack.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/AvatarStack/AvatarStack.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const AvatarStack = () => {
+  return <div />;
+};
+
+export default AvatarStack;

--- a/FE/src/components/Issues/IssueTable/IssueList/Contents/Contents.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/Contents/Contents.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Contents = () => {
+  return <div />;
+};
+
+export default Contents;

--- a/FE/src/components/Issues/IssueTable/IssueList/Contents/Details.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/Contents/Details.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Details = () => {
+  return <div />;
+};
+
+export default Details;

--- a/FE/src/components/Issues/IssueTable/IssueList/Contents/Label.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/Contents/Label.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Label = () => {
+  return <div />;
+};
+
+export default Label;

--- a/FE/src/components/Issues/IssueTable/IssueList/Contents/Title.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/Contents/Title.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Title = () => {
+  return <div />;
+};
+
+export default Title;

--- a/FE/src/components/Issues/IssueTable/IssueList/IssueList.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/IssueList.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const IssueList = () => {
+  return <div />;
+};
+
+export default IssueList;

--- a/FE/src/components/Issues/IssueTable/IssueList/StatusIcon.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueList/StatusIcon.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const StatusIcon = () => {
+  return <div />;
+};
+
+export default StatusIcon;

--- a/FE/src/components/Issues/IssueTable/IssueTable.jsx
+++ b/FE/src/components/Issues/IssueTable/IssueTable.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const IssueTable = () => {
+  return <div />;
+};
+
+export default IssueTable;

--- a/FE/src/components/Issues/IssueTable/Toolbar/SelectedNumber.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/SelectedNumber.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SelectedNumber = () => {
+  return <div />;
+};
+
+export default SelectedNumber;

--- a/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/Menu.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/Menu.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Menu = () => {
+  return <div />;
+};
+
+export default Menu;

--- a/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/TableFilters.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/TableFilters.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const TableFilters = () => {
+  return <div />;
+};
+
+export default TableFilters;

--- a/FE/src/components/Issues/IssueTable/Toolbar/Toolbar.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/Toolbar.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Toolbar = () => {
+  return <div />;
+};
+
+export default Toolbar;

--- a/FE/src/components/Issues/IssueTable/Toolbar/TotalCheckBox.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/TotalCheckBox.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const TotalCheckBox = () => {
+  return <div />;
+};
+
+export default TotalCheckBox;

--- a/FE/src/components/Issues/Navigation/Filter/ClearButton.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/ClearButton.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ClearButton = () => {
+  return <div />;
+};
+
+export default ClearButton;

--- a/FE/src/components/Issues/Navigation/Filter/Filter.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/Filter.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Filter = () => {
+  return <div />;
+};
+
+export default Filter;

--- a/FE/src/components/Issues/Navigation/Filter/Menu.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/Menu.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Menu = () => {
+  return <div />;
+};
+
+export default Menu;

--- a/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SearchBar = () => {
+  return <div />;
+};
+
+export default SearchBar;

--- a/FE/src/components/Issues/Navigation/LinkButtons/Labels.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/Labels.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Labels = () => {
+  return <div />;
+};
+
+export default Labels;

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const LinkButtons = () => {
+  return <div />;
+};
+
+export default LinkButtons;

--- a/FE/src/components/Issues/Navigation/LinkButtons/Milestones.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/Milestones.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Milestones = () => {
+  return <div />;
+};
+
+export default Milestones;

--- a/FE/src/components/Issues/Navigation/Navigation.jsx
+++ b/FE/src/components/Issues/Navigation/Navigation.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Navigation = () => {
+  return <div />;
+};
+
+export default Navigation;

--- a/FE/src/components/Issues/Navigation/NewIssueButton.jsx
+++ b/FE/src/components/Issues/Navigation/NewIssueButton.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NewIssueButton = () => {
+  return <div />;
+};
+
+export default NewIssueButton;

--- a/FE/src/components/common/Header.jsx
+++ b/FE/src/components/common/Header.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Header = () => {
+  return <div />;
+};
+
+export default Header;

--- a/FE/src/pages/DetailedIssue.jsx
+++ b/FE/src/pages/DetailedIssue.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DetailedIssue = () => {
+  return <div />;
+};
+
+export default DetailedIssue;

--- a/FE/src/pages/EditMilestone.jsx
+++ b/FE/src/pages/EditMilestone.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const EditMilestone = () => {
+  return <div />;
+};
+
+export default EditMilestone;

--- a/FE/src/pages/Issues.jsx
+++ b/FE/src/pages/Issues.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Issues = () => {
+  return <div />;
+};
+
+export default Issues;

--- a/FE/src/pages/Labels.jsx
+++ b/FE/src/pages/Labels.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Labels = () => {
+  return <div />;
+};
+
+export default Labels;

--- a/FE/src/pages/Login.jsx
+++ b/FE/src/pages/Login.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Login = () => {
+  return <div />;
+};
+
+export default Login;

--- a/FE/src/pages/Milestones.jsx
+++ b/FE/src/pages/Milestones.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Milestones = () => {
+  return <div />;
+};
+
+export default Milestones;

--- a/FE/src/pages/NewIssue.jsx
+++ b/FE/src/pages/NewIssue.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NewIssue = () => {
+  return <div />;
+};
+
+export default NewIssue;

--- a/FE/src/pages/NewMilestone.jsx
+++ b/FE/src/pages/NewMilestone.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NewMilestone = () => {
+  return <div />;
+};
+
+export default NewMilestone;


### PR DESCRIPTION
## 개요

- 이슈 리스트 화면의 컴포넌트를 설계했습니다.
- 여러 페이지를 파일별로 분리했습니다.

## 작업사항

### 컴포넌트 설계

- `components` 디렉토리 내부 `issues`폴더에 이슈 리스트 화면 컴포넌트를 분리했습니다.
- `common`폴더에 공통으로 사용되는 헤더 컴포넌트 파일을 두었습니다.
- `pages`폴더에 있는 페이지들로 라우팅이 이루어집니다.
- **컴포넌트 재사용 여부에 따라 구조는 추후 변경될 수 있습니다.**

### 페이지 Route 분류

|번호|종류|페이지명|주소|
|---|---|---|---|
1 | 로그인 | Login | `/login`
2 | 이슈 목록 | Issues | default: `/issues`<br>filter: `/issues/{filterQueries}`
3 | 이슈 생성 | NewIssue | `/issues/new`
4 | 이슈 상세 | DetailedIssue | `/issues/{issueID}`
5 | 라벨 목록 | Labels | `/labels`
6 | 마일스톤 목록 | Milestones | `/milestones`
7 | 마일스톤 수정 | EditMilestone | `/milestones/{milestoneID}/edit`
8 | 마일스톤 생성 | NewMilestone | `/milestones/new`

---

- Close #5 

