### PR TITLE
[FE] 레이블, 마일스톤 버튼 UI

### DIFF
--- a/FE/src/components/Issues/Navigation/Filter/Menu.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/Menu.jsx
@@ -65,6 +65,7 @@ const useStyles = makeStyles((theme) => ({
   button: {
     border: "1px solid" + grey[400],
     borderRadius: "5px 0  0 5px",
+    textTransform: "none",
   },
   filterText: {
     fontSize: 13,

--- a/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme) => ({
     "&:hover": {
       backgroundColor: fade(grey[300], 0.25),
     },
-    width: 450,
+    width: "100%",
   },
   searchIcon: {
     padding: theme.spacing(0, 2),
@@ -61,7 +61,7 @@ const useStyles = makeStyles((theme) => ({
     transition: theme.transitions.create("width"),
     height: "100%",
     [theme.breakpoints.up("md")]: {
-      width: "450px",
+      width: "500px",
     },
   },
 }));

--- a/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
@@ -30,6 +30,7 @@ const SearchBar = () => {
 
 const useStyles = makeStyles((theme) => ({
   search: {
+    height: 32.5,
     position: "relative",
     borderRadius: "0 5px 5px 0",
     border: "1px solid" + grey[400],
@@ -54,7 +55,6 @@ const useStyles = makeStyles((theme) => ({
     color: "inherit",
   },
   inputInput: {
-    boxSizing: "border-box",
     padding: theme.spacing(1, 1, 1, 0),
     color: grey[700],
     paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,

--- a/FE/src/components/Issues/Navigation/LinkButtons/Labels.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/Labels.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const Labels = () => {
-  return <div />;
+  return <></>;
 };
 
 export default Labels;

--- a/FE/src/components/Issues/Navigation/LinkButtons/Labels.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/Labels.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const Labels = () => {
-  return <></>;
-};
-
-export default Labels;

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
@@ -17,6 +17,7 @@ const LinkButton = ({ text, count }) => {
 
 const useStyles = makeStyles(() => ({
   root: {
+    textTransform: "none",
     "& span": {
       fontWeight: "bold",
       fontSize: 13,

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
@@ -6,7 +6,7 @@ import grey from "@material-ui/core/colors/grey";
 
 const LinkButton = ({ text, count }) => {
   const classes = useStyles();
-  console.log(text, count);
+
   return (
     <Button variant="outlined" className={classes.root}>
       <span>{text}</span>

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 import Button from "@material-ui/core/Button";
 import { makeStyles } from "@material-ui/core/styles";
@@ -10,7 +11,7 @@ const LinkButton = ({ text, count }) => {
   return (
     <Button variant="outlined" className={classes.root}>
       <span>{text}</span>
-      <span className={classes.count}>{count}</span>
+      {count && <span className={classes.count}>{count}</span>}
     </Button>
   );
 };
@@ -33,5 +34,10 @@ const useStyles = makeStyles(() => ({
     backgroundColor: grey[300],
   },
 }));
+
+LinkButton.propTypes = {
+  text: PropTypes.string.isRequired,
+  count: PropTypes.number,
+};
 
 export default LinkButton;

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
@@ -4,20 +4,28 @@ import Button from "@material-ui/core/Button";
 import { makeStyles } from "@material-ui/core/styles";
 import grey from "@material-ui/core/colors/grey";
 
-const LinkButton = () => {
+const LinkButton = ({ text, count }) => {
   const classes = useStyles();
-
+  console.log(text, count);
   return (
     <div>
-      <Button variant="outlined">
-        <span>Default</span>
-        <span className={classes.count}>2</span>
+      <Button variant="outlined" className={classes.root}>
+        <span>{text}</span>
+        <span className={classes.count}>{count}</span>
       </Button>
     </div>
   );
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
+  root: {
+    "& span": {
+      fontWeight: "bold",
+      fontSize: 13,
+      color: grey[700],
+    },
+  },
+
   count: {
     borderRadius: "50%",
     marginLeft: 5,

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import Button from "@material-ui/core/Button";
+import { makeStyles } from "@material-ui/core/styles";
+import grey from "@material-ui/core/colors/grey";
+
+const LinkButton = () => {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <Button variant="outlined">
+        <span>Default</span>
+        <span className={classes.count}>2</span>
+      </Button>
+    </div>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  count: {
+    borderRadius: "50%",
+    marginLeft: 5,
+    display: "inline-block",
+    padding: "0 8px",
+    backgroundColor: grey[300],
+  },
+}));
+
+export default LinkButton;

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
@@ -8,12 +8,10 @@ const LinkButton = ({ text, count }) => {
   const classes = useStyles();
   console.log(text, count);
   return (
-    <div>
-      <Button variant="outlined" className={classes.root}>
-        <span>{text}</span>
-        <span className={classes.count}>{count}</span>
-      </Button>
-    </div>
+    <Button variant="outlined" className={classes.root}>
+      <span>{text}</span>
+      <span className={classes.count}>{count}</span>
+    </Button>
   );
 };
 

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import LinkButton from "./LinkButton";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
 import { makeStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
 
 const labelCount = 8,
   milestonesCount = 3; //상태값으로 변경
@@ -10,7 +11,6 @@ const labelCount = 8,
 const LinkButtons = () => {
   const LABELS = "Labels";
   const MILESTONES = "Milestones";
-  console.log(LABELS, 1);
 
   const classes = useStyles();
   return (
@@ -18,6 +18,7 @@ const LinkButtons = () => {
       <ButtonGroup aria-label="outlined primary button group">
         <LinkButton text={LABELS} count={labelCount} />
         <LinkButton text={MILESTONES} count={milestonesCount} />
+        <Button></Button>
       </ButtonGroup>
     </div>
   );

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 import LinkButton from "./LinkButton";
+import ButtonGroup from "@material-ui/core/ButtonGroup";
+import { makeStyles } from "@material-ui/core/styles";
 
 const labelCount = 8,
   milestonesCount = 3; //상태값으로 변경
@@ -10,12 +12,22 @@ const LinkButtons = () => {
   const MILESTONES = "Milestones";
   console.log(LABELS, 1);
 
+  const classes = useStyles();
   return (
-    <>
-      <LinkButton text={LABELS} count={labelCount} />
-      <LinkButton text={MILESTONES} count={milestonesCount} />
-    </>
+    <div className={classes.root}>
+      <ButtonGroup aria-label="outlined primary button group">
+        <LinkButton text={LABELS} count={labelCount} />
+        <LinkButton text={MILESTONES} count={milestonesCount} />
+      </ButtonGroup>
+    </div>
   );
 };
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    // marginLeft: theme.spacing(5),
+    // marginRight: theme.spacing(5),
+  },
+}));
 
 export default LinkButtons;

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
@@ -2,33 +2,20 @@ import React from "react";
 
 import LinkButton from "./LinkButton";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
-import { makeStyles } from "@material-ui/core/styles";
-import Button from "@material-ui/core/Button";
 
 const labelCount = 8,
-  milestonesCount = 3; //상태값으로 변경
+  milestonesCount = 3; //상태값으로 변경하기
 
 const LinkButtons = () => {
   const LABELS = "Labels";
   const MILESTONES = "Milestones";
 
-  const classes = useStyles();
   return (
-    <div className={classes.root}>
-      <ButtonGroup aria-label="outlined primary button group">
-        <LinkButton text={LABELS} count={labelCount} />
-        <LinkButton text={MILESTONES} count={milestonesCount} />
-        <Button></Button>
-      </ButtonGroup>
-    </div>
+    <ButtonGroup aria-label="outlined primary button group">
+      <LinkButton text={LABELS} count={labelCount} />
+      <LinkButton text={MILESTONES} count={milestonesCount} />
+    </ButtonGroup>
   );
 };
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    // marginLeft: theme.spacing(5),
-    // marginRight: theme.spacing(5),
-  },
-}));
 
 export default LinkButtons;

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButtons.jsx
@@ -1,7 +1,21 @@
 import React from "react";
 
+import LinkButton from "./LinkButton";
+
+const labelCount = 8,
+  milestonesCount = 3; //상태값으로 변경
+
 const LinkButtons = () => {
-  return <div />;
+  const LABELS = "Labels";
+  const MILESTONES = "Milestones";
+  console.log(LABELS, 1);
+
+  return (
+    <>
+      <LinkButton text={LABELS} count={labelCount} />
+      <LinkButton text={MILESTONES} count={milestonesCount} />
+    </>
+  );
 };
 
 export default LinkButtons;

--- a/FE/src/components/Issues/Navigation/LinkButtons/Milestones.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/Milestones.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-const Milestones = () => {
-  return <div />;
-};
-
-export default Milestones;

--- a/FE/src/components/Issues/Navigation/Navigation.jsx
+++ b/FE/src/components/Issues/Navigation/Navigation.jsx
@@ -1,13 +1,15 @@
 import React from "react";
 
 import Filter from "./Filter/Filter";
+import LinkButtons from "./LinkButtons/LinkButton";
 
 import Box from "@material-ui/core/Box";
 
 const Navigation = () => {
   return (
-    <Box component="nav" mt={6} mb={5}>
+    <Box component="nav" mt={6} mb={5} display="flex">
       <Filter />
+      <LinkButtons />
     </Box>
   );
 };

--- a/FE/src/components/Issues/Navigation/Navigation.jsx
+++ b/FE/src/components/Issues/Navigation/Navigation.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import Filter from "./Filter/Filter";
-import LinkButtons from "./LinkButtons/LinkButton";
+import LinkButtons from "./LinkButtons/LinkButtons";
 
 import Box from "@material-ui/core/Box";
 

--- a/FE/src/components/Issues/Navigation/Navigation.jsx
+++ b/FE/src/components/Issues/Navigation/Navigation.jsx
@@ -7,7 +7,7 @@ import Box from "@material-ui/core/Box";
 
 const Navigation = () => {
   return (
-    <Box component="nav" mt={6} mb={5} display="flex">
+    <Box component="nav" mt={6} mb={5} display="flex" justifyContent="space-between">
       <Filter />
       <LinkButtons />
     </Box>

--- a/FE/src/components/common/MenuList.jsx
+++ b/FE/src/components/common/MenuList.jsx
@@ -11,7 +11,6 @@ const MenuList = ({ text, title }) => {
   const boxClassName = title ? classes.titleBox : classes.popupBox;
   const boxText = title ? title : text;
   const boxFontWeight = title ? "bold" : "none";
-
   return (
     <Box py={1} px={2} className={boxClassName}>
       <Typography style={{ fontSize: "13px", fontWeight: boxFontWeight }}>{boxText}</Typography>


### PR DESCRIPTION
## 개요

- 레이블, 마일스톤 버튼 UI

## 작업사항

- 레이블, 마일스톤 버튼 생성
- button group으로 두 버튼 하나로 묶음
- 버튼 대문자 -> 소문자로 변경
- LinkButton 컴포넌트 propTypes지정

## 변경로직

- LinkButtons 폴더 안에 컴포넌트 구조가 조금 변경되었습니다.
기존에 Labels, Milestones 버튼 컴포넌트가 각각 존재했지만 두 버튼은 같은 형식 버튼이기에 하나의 버튼 컴포넌트로 재사용했습니다. 버튼 컴포넌트 이름은 `LinkButton`입니다.

### 변경전
```
  └─LinkButtons
      LinkButtons.jsx
      Labels.jsx
      Milestones.jsx
   ``` 
### 변경후
```
└─LinkButtons
      LinkButtons.jsx
      LinkButton.jsx
```

## 미구현 기능

- 절대경로는 에드가 작업한 내용과 merge 한 뒤 추가하겠습니다.
- 버튼 앞에 아이콘은 넣지 않았습니다. (추후 여유가 된다면 추가 예정)

## 고민사항

- button group으로 두 버튼을 묶었는데 button을 다른 컴포넌트로 분리 후 묶었더니 버튼의 border-radius 부분이 자연스럽게 묶이지 않는 것 같습니다. 이 부분도 기능 구현 후 여유가 된다면 방법을 생각해보겠습니다. 

---
Closed #6 