### PR TITLE
[FE] 이슈 생성 버튼 UI 

### DIFF
--- a/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles((theme) => ({
     transition: theme.transitions.create("width"),
     height: "100%",
     [theme.breakpoints.up("md")]: {
-      width: "500px",
+      width: "550px",
     },
   },
 }));

--- a/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
+++ b/FE/src/components/Issues/Navigation/LinkButtons/LinkButton.jsx
@@ -19,6 +19,7 @@ const LinkButton = ({ text, count }) => {
 const useStyles = makeStyles(() => ({
   root: {
     textTransform: "none",
+    padding: "0 20px",
     "& span": {
       fontWeight: "bold",
       fontSize: 13,

--- a/FE/src/components/Issues/Navigation/Navigation.jsx
+++ b/FE/src/components/Issues/Navigation/Navigation.jsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import Filter from "./Filter/Filter";
 import LinkButtons from "./LinkButtons/LinkButtons";
+import NewIssueButton from "./NewIssueButton";
 
 import Box from "@material-ui/core/Box";
 
@@ -10,6 +11,7 @@ const Navigation = () => {
     <Box component="nav" mt={6} mb={5} display="flex" justifyContent="space-between">
       <Filter />
       <LinkButtons />
+      <NewIssueButton />
     </Box>
   );
 };

--- a/FE/src/components/Issues/Navigation/Navigation.jsx
+++ b/FE/src/components/Issues/Navigation/Navigation.jsx
@@ -8,7 +8,7 @@ import Box from "@material-ui/core/Box";
 
 const Navigation = () => {
   return (
-    <Box component="nav" mt={6} mb={5} display="flex" justifyContent="space-between">
+    <Box component="nav" mt={6} mb={5} maxHeight={38} display="flex" justifyContent="space-between">
       <Filter />
       <LinkButtons />
       <NewIssueButton />

--- a/FE/src/components/Issues/Navigation/NewIssueButton.jsx
+++ b/FE/src/components/Issues/Navigation/NewIssueButton.jsx
@@ -1,7 +1,15 @@
 import React from "react";
 
+import { makeStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+
 const NewIssueButton = () => {
-  return <div />;
+  const NEW_ISSUE_BTN_TEXT = "New issue";
+  return (
+    <Button variant="contained" color="primary" disableElevation>
+      {NEW_ISSUE_BTN_TEXT}
+    </Button>
+  );
 };
 
 export default NewIssueButton;

--- a/FE/src/components/Issues/Navigation/NewIssueButton.jsx
+++ b/FE/src/components/Issues/Navigation/NewIssueButton.jsx
@@ -2,14 +2,29 @@ import React from "react";
 
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
+import grey from "@material-ui/core/colors/grey";
 
 const NewIssueButton = () => {
   const NEW_ISSUE_BTN_TEXT = "New issue";
+  const classes = useStyles();
+
   return (
-    <Button variant="contained" color="primary" disableElevation>
+    <Button variant="contained" disableElevation className={classes.button}>
       {NEW_ISSUE_BTN_TEXT}
     </Button>
   );
 };
+
+const useStyles = makeStyles((theme) => ({
+  button: {
+    border: "1px solid" + grey[600],
+    textTransform: "none",
+    backgroundColor: theme.palette.success.main,
+    color: theme.palette.common.white,
+    "&:hover": {
+      backgroundColor: theme.palette.success.dark,
+    },
+  },
+}));
 
 export default NewIssueButton;


### PR DESCRIPTION
## 개요

- 이슈 생성 버튼 UI 

## 작업사항

- 이슈 생성 버튼
- hover시 색상 변경

## 기타

- 버튼 색상은 github와 똑같이 하지 않고 저번에 약속한 기본 테마에 맞추기 위해 material-ui Default Theme success 컬러를 사용했습니다.
---
Closed #42 