### PR TITLE
[FE] 테이블 Toolbar 필터버튼 UI

### DIFF
--- a/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/FilterButton.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/FilterButton.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Button from "@material-ui/core/Button";
+import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
+
+const FilterButton = ({ text }) => {
+  return (
+    <Button aria-controls={text}>
+      {text}
+      <ArrowDropDownIcon />
+    </Button>
+  );
+};
+
+FilterButton.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+export default FilterButton;

--- a/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/TableFilters.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/TableFilters.jsx
@@ -6,15 +6,15 @@ import Box from "@material-ui/core/Box";
 import FilterButton from "./FilterButton";
 
 const TableFilters = ({ bSelectedIssueExist }) => {
-  const markAsFilter = "Mark as";
+  const markAsFilterButton = "Mark as";
   const filterButtonList = ["Author", "Label", "Projects", "Milestones", "Assignees", "Sort"];
 
   return (
     <Box>
       {bSelectedIssueExist ? (
-        <FilterButton text={markAsFilter} />
+        <FilterButton text={markAsFilterButton} />
       ) : (
-        filterButtonList.map((buttonText) => <FilterButton text={buttonText} />)
+        filterButtonList.map((buttonText) => <FilterButton key={buttonText} text={buttonText} />)
       )}
     </Box>
   );

--- a/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/TableFilters.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/TableFilters/TableFilters.jsx
@@ -1,7 +1,27 @@
 import React from "react";
+import PropTypes from "prop-types";
 
-const TableFilters = () => {
-  return <div />;
+import Box from "@material-ui/core/Box";
+
+import FilterButton from "./FilterButton";
+
+const TableFilters = ({ bSelectedIssueExist }) => {
+  const markAsFilter = "Mark as";
+  const filterButtonList = ["Author", "Label", "Projects", "Milestones", "Assignees", "Sort"];
+
+  return (
+    <Box>
+      {bSelectedIssueExist ? (
+        <FilterButton text={markAsFilter} />
+      ) : (
+        filterButtonList.map((buttonText) => <FilterButton text={buttonText} />)
+      )}
+    </Box>
+  );
+};
+
+TableFilters.propTypes = {
+  bSelectedIssueExist: PropTypes.bool.isRequired,
 };
 
 export default TableFilters;

--- a/FE/src/components/Issues/IssueTable/Toolbar/Toolbar.jsx
+++ b/FE/src/components/Issues/IssueTable/Toolbar/Toolbar.jsx
@@ -1,12 +1,11 @@
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 
 import Box from "@material-ui/core/Box";
 import Typography from "@material-ui/core/Typography";
-import Button from "@material-ui/core/Button";
 import Checkbox from "@material-ui/core/Checkbox";
-import Menu from "@material-ui/core/Menu";
-import MenuItem from "@material-ui/core/MenuItem";
+
+import TableFilters from "./TableFilters/TableFilters";
 
 const Toolbar = ({
   selectedIssueSize,
@@ -14,11 +13,6 @@ const Toolbar = ({
   bAllSelectedIssue,
   clickHandler,
 }) => {
-  const [anchorEl, setAnchorEl] = useState(null);
-
-  const handleMenuClick = (event) => setAnchorEl(event.currentTarget);
-  const handleMenuClose = () => setAnchorEl(null);
-
   const SELECTED_TEXT = "selected";
 
   return (
@@ -36,20 +30,7 @@ const Toolbar = ({
           </Typography>
         )}
       </Box>
-      <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleMenuClick}>
-        Open Menu
-      </Button>
-      <Menu
-        id="simple-menu"
-        anchorEl={anchorEl}
-        keepMounted
-        open={!!anchorEl}
-        onClose={handleMenuClose}
-      >
-        <MenuItem onClick={handleMenuClose}>Profile</MenuItem>
-        <MenuItem onClick={handleMenuClose}>My account</MenuItem>
-        <MenuItem onClick={handleMenuClose}>Logout</MenuItem>
-      </Menu>
+      <TableFilters bSelectedIssueExist={!!selectedIssueSize} />
     </>
   );
 };

--- a/FE/src/components/Issues/Navigation/Filter/Filter.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/Filter.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 
+import Box from "@material-ui/core/Box";
 import Menu from "./Menu";
 import SearchBar from "./SearchBar";
-
-import Box from "@material-ui/core/Box";
 
 const Filter = () => {
   return (

--- a/FE/src/components/Issues/Navigation/Filter/Menu.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/Menu.jsx
@@ -16,7 +16,7 @@ const Menu = () => {
   const FILTER_BTN_TEXT = "Filters";
   const classes = useStyles();
 
-  const menuList = mockArr.map((text, i) => <MenuList text={text} key={text + i} />);
+  const menuList = mockArr.map((text) => <MenuList text={text} key={text} />);
   return (
     <PopupState variant="popover" popupId="demo-popup-popover">
       {(popupState) => (
@@ -53,7 +53,7 @@ const Menu = () => {
   );
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   button: {
     border: `1px solid${grey[400]}`,
     borderRadius: "5px 0  0 5px",

--- a/FE/src/components/Issues/Navigation/Filter/Menu.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/Menu.jsx
@@ -55,7 +55,7 @@ const Menu = () => {
 
 const useStyles = makeStyles((theme) => ({
   button: {
-    border: "1px solid" + grey[400],
+    border: `1px solid${grey[400]}`,
     borderRadius: "5px 0  0 5px",
     textTransform: "none",
   },

--- a/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
+++ b/FE/src/components/Issues/Navigation/Filter/SearchBar.jsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles((theme) => ({
     height: 32.5,
     position: "relative",
     borderRadius: "0 5px 5px 0",
-    border: "1px solid" + grey[400],
+    border: `1px solid${grey[400]}`,
     borderLeft: "none",
     backgroundColor: grey[50],
     "&:hover": {

--- a/FE/src/components/Issues/Navigation/Navigation.jsx
+++ b/FE/src/components/Issues/Navigation/Navigation.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 
+import Box from "@material-ui/core/Box";
 import Filter from "./Filter/Filter";
 import LinkButtons from "./LinkButtons/LinkButtons";
 import NewIssueButton from "./NewIssueButton";
-
-import Box from "@material-ui/core/Box";
 
 const Navigation = () => {
   return (

--- a/FE/src/components/Issues/Navigation/NewIssueButton.jsx
+++ b/FE/src/components/Issues/Navigation/NewIssueButton.jsx
@@ -17,7 +17,7 @@ const NewIssueButton = () => {
 
 const useStyles = makeStyles((theme) => ({
   button: {
-    border: "1px solid" + grey[600],
+    border: `1px solid${grey[600]}`,
     textTransform: "none",
     backgroundColor: theme.palette.success.main,
     color: theme.palette.common.white,

--- a/FE/src/components/common/Header.jsx
+++ b/FE/src/components/common/Header.jsx
@@ -4,12 +4,14 @@ import styled from "styled-components";
 import CollectionsBookmarkIcon from "@material-ui/icons/CollectionsBookmark";
 
 const Header = () => {
+  const TITLE_TEXT = "Issues";
+
   return (
     <HeaderWrap>
       <BookIcon>
         <CollectionsBookmarkIcon fontSize="small" />
       </BookIcon>
-      <Title>lssues</Title>
+      <Title>{TITLE_TEXT}</Title>
     </HeaderWrap>
   );
 };

--- a/FE/src/components/common/MenuList.jsx
+++ b/FE/src/components/common/MenuList.jsx
@@ -12,6 +12,7 @@ const MenuList = ({ text, title }) => {
   const boxClassName = title ? classes.titleBox : classes.popupBox;
   const boxText = title || text;
   const boxFontWeight = title ? "bold" : "none";
+
   return (
     <Box py={1} px={2} className={boxClassName}>
       <Typography style={{ fontSize: "13px", fontWeight: boxFontWeight }}>{boxText}</Typography>
@@ -33,9 +34,14 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+MenuList.defaultProps = {
+  text: "",
+  title: "",
+};
+
 MenuList.propTypes = {
-  text: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  text: PropTypes.string,
+  title: PropTypes.string,
 };
 
 export default MenuList;

--- a/FE/src/components/common/MenuList.jsx
+++ b/FE/src/components/common/MenuList.jsx
@@ -34,8 +34,8 @@ const useStyles = makeStyles(() => ({
 }));
 
 MenuList.propTypes = {
-  text: PropTypes.string,
-  title: PropTypes.string,
+  text: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default MenuList;

--- a/FE/src/components/common/MenuList.jsx
+++ b/FE/src/components/common/MenuList.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Typography from "@material-ui/core/Typography";
-import Box from "@material-ui/core/Box";
 import { makeStyles } from "@material-ui/core/styles";
-import grey from "@material-ui/core/colors/grey";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
 
 const MenuList = ({ text, title }) => {
   const classes = useStyles();
@@ -20,17 +19,17 @@ const MenuList = ({ text, title }) => {
   );
 };
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   popupBox: {
     width: 250,
     cursor: "pointer",
-    borderTop: `1px solid${grey[300]}`,
+    borderTop: `1px solid${theme.palette.grey[300]}`,
     "&:hover": {
-      backgroundColor: grey[200],
+      backgroundColor: theme.palette.grey[200],
     },
   },
   titleBox: {
-    backgroundColor: grey[200],
+    backgroundColor: theme.palette.grey[200],
   },
 }));
 

--- a/FE/src/components/common/MenuList.jsx
+++ b/FE/src/components/common/MenuList.jsx
@@ -10,7 +10,7 @@ const MenuList = ({ text, title }) => {
   const classes = useStyles();
 
   const boxClassName = title ? classes.titleBox : classes.popupBox;
-  const boxText = title ? title : text;
+  const boxText = title || text;
   const boxFontWeight = title ? "bold" : "none";
   return (
     <Box py={1} px={2} className={boxClassName}>
@@ -23,7 +23,7 @@ const useStyles = makeStyles(() => ({
   popupBox: {
     width: 250,
     cursor: "pointer",
-    borderTop: "1px solid" + grey[300],
+    borderTop: `1px solid${grey[300]}`,
     "&:hover": {
       backgroundColor: grey[200],
     },
@@ -45,5 +45,5 @@ export default MenuList;
 // 2. menuList로써 hover와 마우스 클릭이 되는 list로 사용
 // title로 사용 시 : props로 title을 사용하고 title에 들어갈 text를 넣어주면 됩니다.
 // (예) <MenuList title="Filter lssues" />
-//menuList로 사용 시 : props로 text를 사용하고 list에 들어갈 text를 넣어주면 됩니다.
+// menuList로 사용 시 : props로 text를 사용하고 list에 들어갈 text를 넣어주면 됩니다.
 // (예) <MenuList text="Open issues" />


### PR DESCRIPTION
## 개요

<img width="1267" alt="스크린샷 2020-06-17 오후 3 44 56" src="https://user-images.githubusercontent.com/58209009/84864380-8bd65180-b0b1-11ea-8de7-cb2dbcad5e9a.png">
<img width="1262" alt="스크린샷 2020-06-17 오후 3 44 59" src="https://user-images.githubusercontent.com/58209009/84864376-8aa52480-b0b1-11ea-848a-ecdae4f15d80.png">

- 유저 리스트 테이블의 Filter 버튼의 UI 제작

## 작업사항

- 유저 리스트 테이블의 필터 버튼들의 UI 제작
- 누르면 나오는 메뉴는 구현 x
- 체크 여부에 따라 Mark as / 다른 필터들 식으로 변경됩니다
- 컴포넌트 재사용을 위해 `FilterButton` 컴포넌트 추가했습니다.
- Prettier, ESLint 오류가 뜨는 것들을 수정했습니다
- PropTypes 기본값을 추가했습니다

## 변경로직

### key 값 수정

key값에 인덱스 값을 쓰지 말라는 에러가 떠서 수정했습니다. key값에 그냥 텍스트값을 넣어주셔도 됩니다! 고유한 값이기만 하면 상관없어요

#### 변경전

```js
const menuList = mockArr.map((text, i) => <MenuList text={text} key={text + i} />);
```

#### 변경후

```js
const menuList = mockArr.map((text) => <MenuList text={text} key={text} />);
```

### PropTypes 기본값 설정

MenuList 컴포넌트에 기본값을 추가했습니다. `isRequired`가 아니라면 기본값을 추가해주셔야 에디터 상에 있는 빨간줄(에러)가 사라집니다!

```js
MenuList.defaultProps = {
  text: "",
  title: "",
};
```

## 기타

- Ellin님 현재 Prettier나 ESLint가 에디터 내에서 auto-save 설정이 돼있는지 한 번만 확인 부탁드립니다. 몇 군데에서 코드 스타일 충돌이 일어나는 듯 합니다
- Close #37 